### PR TITLE
Allow portal frame corners to be any occluding block

### DIFF
--- a/src/main/java/me/gorgeousone/netherview/portal/PortalLocator.java
+++ b/src/main/java/me/gorgeousone/netherview/portal/PortalLocator.java
@@ -201,9 +201,21 @@ public class PortalLocator {
 					if (portalBlock.getType() == Material.OBSIDIAN) {
 						frameBlocks.add(portalBlock);
 						
+					} else if ((((portalAxis == Axis.X) && ((x == portalMinX     && y == portalMinY    ) ||
+					                                        (x == portalMinX     && y == portalMaxY - 1) ||
+					                                        (x == portalMaxX - 1 && y == portalMinY    ) ||
+					                                        (x == portalMaxX - 1 && y == portalMaxY - 1))) ||
+					            ((portalAxis == Axis.Z) && ((z == portalMinZ     && y == portalMinY    ) ||
+					                                        (z == portalMinZ     && y == portalMaxY - 1) ||
+					                                        (z == portalMaxZ - 1 && y == portalMinY    ) ||
+					                                        (z == portalMaxZ - 1 && y == portalMaxY - 1)))) &&
+					           portalBlock.getType().isOccluding()) {
+						//allow corner blocks to be any occluding block
+						frameBlocks.add(portalBlock);
+						
 					} else {
 						
-						MessageUtils.printDebug("Expected obsidian block at "
+						MessageUtils.printDebug("Expected obsidian/occluding block at "
 						                        + portalBlock.getWorld().getName() + ", "
 						                        + new BlockVec(portalBlock).toString());
 						


### PR DESCRIPTION
I noticed that most of the portal frames on my server do not have obsidian blocks in the corners.  They usually have dirt (at ground level) or stone brick blocks in the corners.  This pull request allows the portal frame corners to contain any occluding block.

I realize the if statement is complicated, but I tested all eight cases carefully, using Spigot 1.16.3.  If a frame block is not obsidian, the new code checks to see if the block is at a corner and if it is an occluding block.  If so, the block is considered valid.

I'm not sure of the purpose of frameBlocks.  I added the non-obsidian corner blocks to the Set to be consistent with the current behavior.  I don't know if having blocks other than obsidian in the Set will cause problems, but I didn't observe any.